### PR TITLE
Switch from at_exit to finalizer to avoid squashing test exit code.

### DIFF
--- a/lib/redistat.rb
+++ b/lib/redistat.rb
@@ -96,11 +96,7 @@ module Redistat
     end
     attr_writer :group_separator
 
+    ObjectSpace.define_finalizer(self, proc { Redistat.buffer.flush (true) })
+
   end
-end
-
-
-# ensure buffer is flushed on program exit
-Kernel.at_exit do
-  Redistat.buffer.flush(true)
 end


### PR DESCRIPTION
Credit to @nmeans